### PR TITLE
Make `-dce full` work

### DIFF
--- a/src/io/colyseus/serializer/schema/Schema.hx
+++ b/src/io/colyseus/serializer/schema/Schema.hx
@@ -328,6 +328,7 @@ class DataChange {
   }
 }
 
+@:keep
 @:generic
 class ArraySchema<T> {
   public var items:Array<T> = [];
@@ -372,6 +373,7 @@ class ArraySchema<T> {
 
 }
 
+@:keep
 @:generic
 class MapSchema<T> {
   public var items:Map<String, T> = new Map<String, T>();


### PR DESCRIPTION
Added metadata to keep fields from removal if project's dce is full.