### PR TITLE
Fixing runtime error

### DIFF
--- a/src/io/colyseus/serializer/schema/Schema.hx
+++ b/src/io/colyseus/serializer/schema/Schema.hx
@@ -555,7 +555,7 @@ class Schema {
           var items = cast(valueRef.items, Array<Dynamic>);
 
           for (i in newLength...valueRef.items.length) {
-			var itemRemoved = items[i];
+            var itemRemoved = items[i];
 
             if (isSchemaType && itemRemoved.onRemove != null) {
               itemRemoved.onRemove();

--- a/src/io/colyseus/serializer/schema/Schema.hx
+++ b/src/io/colyseus/serializer/schema/Schema.hx
@@ -555,9 +555,10 @@ class Schema {
           var items = cast(valueRef.items, Array<Dynamic>);
 
           for (i in newLength...valueRef.items.length) {
-            var itemRemoved = items[i];
+			var itemRemoved = items[i];
+			trace('=========',itemRemoved);
 
-            if (isSchemaType) {
+            if (isSchemaType && itemRemoved.onRemove != null) {
               itemRemoved.onRemove();
             }
 
@@ -586,7 +587,7 @@ class Schema {
             if (isNew) {
               item = Type.createInstance(type, []);
             } else if (indexChangedFrom != -1) {
-              item = cast(valueRef, ArraySchema<Schema>).items[indexChangedFrom];
+              item = (cast valueRef).items[indexChangedFrom];
             } else {
               item = (cast valueRef).items[newIndex];
             }

--- a/src/io/colyseus/serializer/schema/Schema.hx
+++ b/src/io/colyseus/serializer/schema/Schema.hx
@@ -588,7 +588,7 @@ class Schema {
             } else if (indexChangedFrom != -1) {
               item = cast(valueRef, ArraySchema<Schema>).items[indexChangedFrom];
             } else {
-              item = cast(valueRef, ArraySchema<Dynamic>).items[newIndex];
+              item = (cast valueRef).items[newIndex];
             }
 
             if (item == null) {

--- a/src/io/colyseus/serializer/schema/Schema.hx
+++ b/src/io/colyseus/serializer/schema/Schema.hx
@@ -556,7 +556,6 @@ class Schema {
 
           for (i in newLength...valueRef.items.length) {
 			var itemRemoved = items[i];
-			trace('=========',itemRemoved);
 
             if (isSchemaType && itemRemoved.onRemove != null) {
               itemRemoved.onRemove();


### PR DESCRIPTION
It does not make sense to cast to specific type because once cast fails it throws. In order to avoid that would be safer to cast normally, since it is Dynamic schema anyway.
would fix #20 