### PR TITLE
Fixes problem when having parameters on a schema class

### DIFF
--- a/src/io/colyseus/serializer/schema/Schema.hx
+++ b/src/io/colyseus/serializer/schema/Schema.hx
@@ -77,13 +77,21 @@ class Decorator {
     }
     classFields.set(localClass.name, index);
 
+    var constructorArgs = [];
+    if(constructor != null){
+      switch (constructor.kind) {
+        case FFun(f):
+          constructorArgs = f.args;
+        default:
+      }
+    }
     // add constructor to fields
     fields.push({
       name: "new",
       pos: haxe.macro.Context.currentPos(),
       access: [APublic],
       kind: FFun({
-        args: [],
+        args: constructorArgs,
         expr: macro $b{exprs},
         params: [],
         ret: null


### PR DESCRIPTION
The macro on schema classes replaces the constructor but didn't keep the parameters, causing "unknown identifier" when trying to access the parameters.